### PR TITLE
Add support for int keys since JSON doesn't support int keys

### DIFF
--- a/types/dict.go
+++ b/types/dict.go
@@ -55,7 +55,13 @@ func (d *Dict) JSON(b *strings.Builder) {
 		} else {
 			b.WriteByte(':')
 		}
-		x.JSON(b)
+		if _, ok := x.(Int); ok {
+			b.WriteByte('"')
+			x.JSON(b)
+			b.WriteByte('"')
+		} else {
+			x.JSON(b)
+		}
 	}
 	b.WriteByte('}')
 }


### PR DESCRIPTION
The pickle file I was parsing had marshaled to JSON with an int key. This isn't supported. I added a check when marshalling dictionaries to check for int keys and wrap them in quotes.